### PR TITLE
allow running systemd in unprivilged container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,5 +79,10 @@ COPY src/confd.service /etc/systemd/system/
 COPY src/journald.conf /etc/systemd/
 COPY src/rsyslog.conf /etc/
 COPY src/logentries.all.crt /opt/ssl/
+COPY src/dbus-no-oom-adjust.conf /etc/systemd/system/dbus.service.d/dbus-no-oom-adjust.conf
+
+VOLUME ["/sys/fs/cgroup"]
+VOLUME ["/run"]
+VOLUME ["/run/lock"]
 
 CMD env > /etc/docker.env; exec /sbin/init

--- a/src/dbus-no-oom-adjust.conf
+++ b/src/dbus-no-oom-adjust.conf
@@ -1,0 +1,2 @@
+[Service]
+OOMScoreAdjust=0


### PR DESCRIPTION
Removed OOMScoreAdjust from dbus and declared a few required mountpoints
as VOLUMEs. Both of these prevent systemd from attempting a privileged
operation.

After this change, this is enough to run the container:
    `docker run -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro resin/resin-base`

We will be able to remove the cgroup read-only bind mount in the future
when cgroup namespace get merged in the kernel.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>