### PR TITLE
update git to version 1:2.1.4-2.1+deb8u2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 		ca-certificates \
 		curl \
 		dbus \
-		git \
+		git=1:2.1.4-2.1+deb8u2 \
 		htop \
 		iptables \
 		less \


### PR DESCRIPTION
fixes CVE-2016-2324

https://security-tracker.debian.org/tracker/CVE-2016-2324

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>