### PR TITLE
automation: add option to build without using cache

### DIFF
--- a/automation/jenkins-build.sh
+++ b/automation/jenkins-build.sh
@@ -3,11 +3,16 @@ set -e
 
 VERSION=$(git rev-parse --short HEAD)
 ESCAPED_BRANCH_NAME=$(echo $sourceBranch | sed 's/[^a-z0-9A-Z_.-]/-/g')
+IGNORE_CACHE=0
 
-# Try pulling the old build first for caching purposes.
-docker pull resin/${JOB_NAME}:${ESCAPED_BRANCH_NAME} || docker pull resin/${JOB_NAME}:master || true
+if [ $IGNORE_CACHE -eq 1 ]; then
+	docker build --pull --no-cache --tag resin/${JOB_NAME}:${VERSION} .
+else
+	# Try pulling the old build first for caching purposes.
+	docker pull resin/${JOB_NAME}:${ESCAPED_BRANCH_NAME} || docker pull resin/${JOB_NAME}:master || true
 
-docker build --tag resin/${JOB_NAME}:${VERSION} .
+	docker build --tag resin/${JOB_NAME}:${VERSION} .
+fi
 
 docker tag -f resin/${JOB_NAME}:${VERSION} resin/${JOB_NAME}:${ESCAPED_BRANCH_NAME}
 docker tag -f resin/${JOB_NAME}:${VERSION} resin/${JOB_NAME}:latest


### PR DESCRIPTION
This can be used to make sure we run the latest debian packages

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>