### PR TITLE
NodeJS Update to version 6.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.8.3
+
+* Update node to 6.11.1
+
+# 2.8.2
+
 * Update rsyslog config to use disk-buffering and retry when connection to logentries fails
 
 # 2.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV NODE_VERSION 6.10.2
+ENV NODE_VERSION 6.11.1
 ENV NPM_VERSION 4.5.0
 
 RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 \


### PR DESCRIPTION
Node version 6.11.1 is a security release, that fixes a couple of security problems in nodejs. https://nodejs.org/en/blog/release/v6.11.1/

Change-Type: patch