### PR TITLE
Update to nodejs 8.12.0 and npm to 6.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN apt-get update \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV NODE_VERSION 8.11.4
-ENV NPM_VERSION 5.10.0
+ENV NODE_VERSION 8.12.0
+ENV NPM_VERSION 6.4.1
 
 RUN curl -SL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | tar xz -C /usr/local --strip-components=1 \
 	&& npm install -g npm@"$NPM_VERSION" \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+The image resin.io services use as a base


### PR DESCRIPTION
The npm update is because it's the version bundled with 8.12.0: https://nodejs.org/en/blog/release/v8.12.0/

Change-type: minor