### PR TITLE
logging: Allow child components	to log to the console

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,6 @@
+---
+docker:
+  builds:
+    - path: .
+      dockerfile: Dockerfile
+      docker_repo: resin/resin-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,9 +89,10 @@ COPY src/journald.conf /etc/systemd/
 COPY src/rsyslog.conf /etc/
 COPY src/dbus-no-oom-adjust.conf /etc/systemd/system/dbus.service.d/dbus-no-oom-adjust.conf
 COPY src/nsswitch.conf /etc/nsswitch.conf
+COPY src/entry.sh /usr/bin/entry.sh
 
 VOLUME ["/sys/fs/cgroup"]
 VOLUME ["/run"]
 VOLUME ["/run/lock"]
 
-CMD env > /etc/docker.env; exec /sbin/init
+CMD ["/usr/bin/entry.sh"]

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -m
+
+GREEN='\033[0;32m'
+echo -e "${GREEN}Systemd init system enabled."
+
+# systemd causes a POLLHUP for console FD to occur
+# on startup once all other process have stopped.
+# We need this sleep to ensure this doesn't occur, else
+# logging to the console will not work.
+sleep infinity &
+env > /etc/docker.env
+exec /sbin/init


### PR DESCRIPTION
Changes to allow backend components to output to the console
should they wish to.

Connects-to: #57
Change-type: minor
Signed-off-by: Heds Simons <heds@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #57