### PR TITLE
dns: Prioritise DNS over MDNS lookups for aliases

### DIFF
--- a/src/nsswitch.conf
+++ b/src/nsswitch.conf
@@ -9,7 +9,7 @@ group:          compat
 shadow:         compat
 gshadow:        files
 
-hosts:          files mdns4_minimal [NOTFOUND=return] dns mdns4
+hosts:          files dns mdns4_minimal [NOTFOUND=return] mdns4
 networks:       files
 
 protocols:      db files


### PR DESCRIPTION
Historically, aliasing of containers occured via the use
of the `--link` (or `links` property of `docker-compose`).
This would be required on each container to ensure that
the relevant alias would be added to the `/etc/hosts` file.

However, this functionality is now deprecated in favour
of the use of the `networks.<name>.aliases` property, set
on a particular service to ensure all other services can
reach that service using the bridge on which they exist.

Unfortunately, this is carried out by adding the records
to the Docker daemon's internal DNS, referenced before
propagating to the host. Whilst this is good in theory,
in the case where MDNS is used (and in particular the
recommended Avahi `libnss-mdns` NS switch config) this
means that MDNS is consulted *before* the Docker DNS
service, in effect meaning that aliases to the internal
IP address for a service are never used, and in effect
negating them.

To counter this, this commit ensures that DNS is
*always* prioritised over MDNS. This has the effect of
querying DNS for `.local` addresses, which can lead
to an initial lag in lookups (although these should then
be cached locally per service), and potentially more DNS
traffic that ideal. However, for the purposes of a
Devenv/OnPrem, this is acceptable.

It has no effect on Cloud deployed instances, as they
will not use `.local` suffixes.

Connects-to: #59
Change-type: patch
Signed-off-by: Heds Simons <heds@resin.io>